### PR TITLE
Add Hash Coin (HASH) to Polygon token list

### DIFF
--- a/assets/assets/0x256a80011034F18dd222b0E85560E4f759781bd6.json
+++ b/assets/assets/0x256a80011034F18dd222b0E85560E4f759781bd6.json
@@ -1,0 +1,8 @@
+{
+  "name": "Hash Coin",
+  "symbol": "HASH",
+  "address": "0x256a80011034F18dd222b0E85560E4f759781bd6",
+  "decimals": 18,
+  "chainId": 137,
+  "logoURI": "https://raw.githubusercontent.com/hashsoos/assets/master/blockchains/polygon/assets/0x256a80011034F18dd222b0E85560E4f759781bd6/logo.png"
+}


### PR DESCRIPTION
HASH is the official community utility token for LAHASHCO on Polygon.

Used to:
- Reward loyal customers
- Unlock exclusive drops
- Access future utilities

Contract: 0x256a80011034F18dd222b0E85560E4f759781bd6  
Symbol: HASH  
Decimals: 18  
Chain ID: 137  
Logo URI: https://raw.githubusercontent.com/hashsoos/assets/master/blockchains/polygon/assets/0x256a80011034F18dd222b0E85560E4f759781bd6/logo.png
